### PR TITLE
Added foreach so we can retrieve $serverID from multiple input

### DIFF
--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -29,15 +29,15 @@ class FilepondController extends BaseController
      */
     public function upload(Request $request)
     {
-        $file = $request->file('file');
+        foreach ($request->file('file') as $file) {
+            $filePath = tempnam(config('filepond.temporary_files_path'), "laravel-filepond");
+            $filePathParts = pathinfo($filePath);
 
-        $filePath = tempnam(config('filepond.temporary_files_path'), "laravel-filepond");
-        $filePathParts = pathinfo($filePath);
-
-        if(!$file->move($filePathParts['dirname'], $filePathParts['basename'])) {
-            return Response::make('Could not save file', 500);
+            if (!$file->move($filePathParts['dirname'], $filePathParts['basename'])) {
+                return Response::make('Could not save file', 500);
+            }
+            return Response::make($this->filepond->getServerIdFromPath($filePath), 200);
         }
-        return Response::make($this->filepond->getServerIdFromPath($filePath), 200);
     }
 
     /**

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -29,15 +29,15 @@ class FilepondController extends BaseController
      */
     public function upload(Request $request)
     {
-        foreach ($request->file('file') as $file) {
-            $filePath = tempnam(config('filepond.temporary_files_path'), "laravel-filepond");
-            $filePathParts = pathinfo($filePath);
+        $file = $request->file('file')[0];
 
-            if (!$file->move($filePathParts['dirname'], $filePathParts['basename'])) {
-                return Response::make('Could not save file', 500);
-            }
-            return Response::make($this->filepond->getServerIdFromPath($filePath), 200);
+        $filePath = tempnam(config('filepond.temporary_files_path'), "laravel-filepond");
+        $filePathParts = pathinfo($filePath);
+
+        if(!$file->move($filePathParts['dirname'], $filePathParts['basename'])) {
+            return Response::make('Could not save file', 500);
         }
+        return Response::make($this->filepond->getServerIdFromPath($filePath), 200);
     }
 
     /**


### PR DESCRIPTION
Solved my #1  problem when using multiple input or `allowMultiple` options and only retrieve one $serverID when using $request->get('file'). Just to make sure, you have to re-configure you `Filepond.setOptions `to: 

```
FilePond.setOptions({
    name: 'file[]',
    server: window.location.protocol+'//'+window.location.hostname+'/filepond/api/process',
})
```