### PR TITLE
Allow save, get and delete of the original filename in cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
   ],
   "require": {
     "php": "^7.0",
-    "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-    "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0"
+    "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0",
+    "illuminate/contracts": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -2,6 +2,7 @@
 
 namespace Sopamo\LaravelFilepond;
 
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
 use Sopamo\LaravelFilepond\Exceptions\InvalidPathException;
@@ -32,5 +33,39 @@ class Filepond {
             throw new InvalidPathException();
         }
         return $filePath;
+    }
+
+    /**
+     * Save the original filename with extension
+     *
+     * @param UploadedFile $uploadedFile
+     * @param string $serverId
+     * @return void
+     */
+    public function saveOriginalFilename($uploadedFile, $serverId)
+    {
+        \Cache::put($serverId . '_orig_name', $uploadedFile->getClientOriginalName(), 60);
+    }
+
+    /**
+     * Get the original filename with extension
+     *
+     * @param string $serverId
+     * @return string
+     */
+    public function getOriginalFileNameFromServerId($serverId)
+    {
+        return \Cache::get($serverId . '_orig_name');
+    }
+
+    /**
+     * Delete the original filename with extension
+     *
+     * @param string $serverId
+     * @return void
+     */
+    public function deleteOriginalFileNameByServerId($serverId)
+    {
+        \Cache::remove($serverId . '_orig_name');
     }
 }

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -37,7 +37,11 @@ class FilepondController extends BaseController
         if(!$file->move($filePathParts['dirname'], $filePathParts['basename'])) {
             return Response::make('Could not save file', 500);
         }
-        return Response::make($this->filepond->getServerIdFromPath($filePath), 200);
+
+        $serverId = $this->filepond->getServerIdFromPath($filePath);
+        $this->filepond->saveOriginalFilename($file, $serverId);
+
+        return Response::make($serverId, 200);
     }
 
     /**
@@ -49,6 +53,7 @@ class FilepondController extends BaseController
      */
     public function delete(Request $request) {
         $filePath = $this->filepond->getPathFromServerId($request->getContent());
+        $this->filepond->deleteOriginalFileNameByServerId($request->getContent());
         if(unlink($filePath)) {
             return Response::make('', 200);
         } else {


### PR DESCRIPTION
I needed a way to get the original filename of the uploaded file. I am sure there are a few ways to do this. It could probably be done on the client side, but when uploading multiple files we would need a way to link each of the serverId's back to the filename. I also tried by storing in the session but this is not possible due to the API route, I believe. I have therefore chosen to save the filename into the Cache with a 60 minute expiry. This is working well for my purpose so thought I would share and get your thoughts.