### PR TITLE
Fixed: Cannot use object of uploaded file as array

### DIFF
--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -29,7 +29,8 @@ class FilepondController extends BaseController
      */
     public function upload(Request $request)
     {
-        $file = $request->file(config('filepond.input_name'))[0];
+        $input = $request->file(config('filepond.input_name'));
+        $file = is_array($input) ? $input[0] : $input;
 
         $tempPath = config('filepond.temporary_files_path');
 


### PR DESCRIPTION
Hi, found a bug. can't upload a single file.

`Symfony\Component\Debug\Exception\FatalThrowableError: Cannot use object of type Illuminate\Http\UploadedFile as array in file C:\laragon\www\rentall\vendor\sopamo\laravel-filepond\src\Http\Controllers\FilepondController.php on line 32`

added check input with is_array