### PR TITLE
Allow using an external disk for temporary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@
 
 Require this package in the `composer.json` of your Laravel project.
 
-```php
+```bash
 composer require sopamo/laravel-filepond
 ```
 
 If you need to edit the configuration, you can publish it with:
 
-```php
+```bash
 php artisan vendor:publish --provider="Sopamo\LaravelFilepond\LaravelFilepondServiceProvider"
 ```
 
@@ -38,6 +38,10 @@ $path = $filepond->getPathFromServerId($serverId);
 $finalLocation = public_path('output.jpg');
 \File::move($path, $finalLocation);
 ```
+
+#### External storage
+
+You can use any [Laravel disk](https://laravel.com/docs/7.x/filesystem) as the storage for temporary files. If you use a different disk for temporary files and final location, you will need to copy the file from the temporary location to the new disk then delete the temporary file yourself.
 
 ### Filepond setup
 

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,10 @@
   ],
   "require": {
     "php": "^7.0",
-    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
-    "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0"
+    "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
+    "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
+    "illuminate/routing": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0",
+    "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0"
   },
   "autoload": {
     "psr-4": {

--- a/config/filepond.php
+++ b/config/filepond.php
@@ -19,6 +19,6 @@ return [
     | When initially uploading the files we store them in this path
     |
     */
-    'temporary_files_path' => 'filepond',
+    'temporary_files_path' => env('FILEPOND_TEMP_PATH', 'filepond'),
     'input_name' => 'file',
 ];

--- a/config/filepond.php
+++ b/config/filepond.php
@@ -13,12 +13,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Local Temporary Path
+    | Temporary Path
     |--------------------------------------------------------------------------
     |
     | When initially uploading the files we store them in this path
+    | By default, it is stored on the local disk which defaults to `/storage/app/{temporary_files_path}`
     |
     */
     'temporary_files_path' => env('FILEPOND_TEMP_PATH', 'filepond'),
+    'temporary_files_disk' => env('FILEPOND_TEMP_DISK', 'local'),
+
     'input_name' => 'file',
 ];

--- a/config/filepond.php
+++ b/config/filepond.php
@@ -19,6 +19,6 @@ return [
     | When initially uploading the files we store them in this path
     |
     */
-    'temporary_files_path' => realpath(sys_get_temp_dir()),
+    'temporary_files_path' => 'filepond',
     'input_name' => 'file',
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('api')->group(function () {

--- a/src/Exceptions/InvalidPathException.php
+++ b/src/Exceptions/InvalidPathException.php
@@ -2,10 +2,11 @@
 
 namespace Sopamo\LaravelFilepond\Exceptions;
 
-class InvalidPathException extends \InvalidArgumentException implements LaravelFilepondException {
+class InvalidPathException extends \InvalidArgumentException implements LaravelFilepondException
+{
     /**
-     * @param string         $message
-     * @param int            $code
+     * @param  string $message
+     * @param  int $code
      */
     public function __construct(
         $message = 'The given file path was invalid',

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -27,18 +27,29 @@ class Filepond
      * @param  string $serverId
      *
      * @return string
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function getPathFromServerId($serverId)
     {
         if (! trim($serverId)) {
             throw new InvalidPathException();
         }
+
         $filePath = Crypt::decryptString($serverId);
-        if (! Str::startsWith($filePath, Storage::disk(config('filepond.temporary_files_disk', 'local'))->path(config('filepond.temporary_files_path', 'filepond')))) {
+        if (! Str::startsWith($filePath, $this->getBasePath())) {
             throw new InvalidPathException();
         }
 
         return $filePath;
+    }
+
+    /**
+     * Get the storage base path for files.
+     *
+     * @return string
+     */
+    public function getBasePath()
+    {
+        return Storage::disk(config('filepond.temporary_files_disk', 'local'))
+            ->path(config('filepond.temporary_files_path', 'filepond'));
     }
 }

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -33,7 +33,7 @@ class Filepond
             throw new InvalidPathException();
         }
         $filePath = Crypt::decryptString($serverId);
-        if (! Str::startsWith($filePath, config('filepond.temporary_files_path'))) {
+        if (! Str::startsWith($filePath, storage_path('app/' . config('filepond.temporary_files_path')))) {
             throw new InvalidPathException();
         }
 

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -3,6 +3,7 @@
 namespace Sopamo\LaravelFilepond;
 
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Sopamo\LaravelFilepond\Exceptions\InvalidPathException;
 
@@ -26,6 +27,7 @@ class Filepond
      * @param  string $serverId
      *
      * @return string
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function getPathFromServerId($serverId)
     {
@@ -33,7 +35,7 @@ class Filepond
             throw new InvalidPathException();
         }
         $filePath = Crypt::decryptString($serverId);
-        if (! Str::startsWith($filePath, storage_path('app/' . config('filepond.temporary_files_path')))) {
+        if (! Str::startsWith($filePath, Storage::disk(config('filepond.temporary_files_disk', 'local'))->path(config('filepond.temporary_files_path', 'filepond')))) {
             throw new InvalidPathException();
         }
 

--- a/src/Filepond.php
+++ b/src/Filepond.php
@@ -6,31 +6,37 @@ use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
 use Sopamo\LaravelFilepond\Exceptions\InvalidPathException;
 
-class Filepond {
+class Filepond
+{
     /**
      * Converts the given path into a filepond server id
      *
-     * @param string $path
+     * @param  string $path
+     *
      * @return string
      */
-    public function getServerIdFromPath($path) {
+    public function getServerIdFromPath($path)
+    {
         return Crypt::encryptString($path);
     }
 
     /**
      * Converts the given filepond server id into a path
      *
-     * @param string $serverId
+     * @param  string $serverId
+     *
      * @return string
      */
-    public function getPathFromServerId($serverId) {
-        if(!trim($serverId)) {
+    public function getPathFromServerId($serverId)
+    {
+        if (! trim($serverId)) {
             throw new InvalidPathException();
         }
         $filePath = Crypt::decryptString($serverId);
-        if(!Str::startsWith($filePath, config('filepond.temporary_files_path'))) {
+        if (! Str::startsWith($filePath, config('filepond.temporary_files_path'))) {
             throw new InvalidPathException();
         }
+
         return $filePath;
     }
 }

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Sopamo\LaravelFilepond\Filepond;
 
 class FilepondController extends BaseController
@@ -39,9 +40,10 @@ class FilepondController extends BaseController
         }
 
         $file = is_array($input) ? $input[0] : $input;
+        $path = config('filepond.temporary_files_path', 'filepond');
         $disk = config('filepond.temporary_files_disk', 'local');
 
-        if (! ($newFile = $file->storeAs(config('filepond.temporary_files_path', 'filepond'), $file->getClientOriginalName(), $disk))) {
+        if (! ($newFile = $file->storeAs($path . DIRECTORY_SEPARATOR . Str::random(), $file->getClientOriginalName(), $disk))) {
             return Response::make('Could not save file', 500, [
                 'Content-Type' => 'text/plain',
             ]);
@@ -59,7 +61,6 @@ class FilepondController extends BaseController
      * @param  Request $request
      *
      * @return mixed
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function delete(Request $request)
     {

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -64,7 +64,7 @@ class FilepondController extends BaseController
     public function delete(Request $request)
     {
         $filePath = $this->filepond->getPathFromServerId($request->getContent());
-        if (unlink($filePath)) {
+        if (Storage::disk(config('filepond.temporary_files_disk', 'local'))->delete($filePath)) {
             return Response::make('', 200, [
                 'Content-Type' => 'text/plain',
             ]);

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -59,6 +59,7 @@ class FilepondController extends BaseController
      * @param  Request $request
      *
      * @return mixed
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
     public function delete(Request $request)
     {

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -2,14 +2,13 @@
 
 namespace Sopamo\LaravelFilepond\Http\Controllers;
 
-use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Response;
 use Sopamo\LaravelFilepond\Filepond;
 
 class FilepondController extends BaseController
 {
-
     /**
      * @var Filepond
      */
@@ -24,7 +23,8 @@ class FilepondController extends BaseController
      * Uploads the file to the temporary directory
      * and returns an encrypted path to the file
      *
-     * @param Request $request
+     * @param  Request $request
+     *
      * @return \Illuminate\Http\Response
      */
     public function upload(Request $request)
@@ -45,7 +45,7 @@ class FilepondController extends BaseController
 
         $filePathParts = pathinfo($filePath);
 
-        if (!$file->move($filePathParts['dirname'], $filePathParts['basename'])) {
+        if (! $file->move($filePathParts['dirname'], $filePathParts['basename'])) {
             return Response::make('Could not save file', 500, [
                 'Content-Type' => 'text/plain',
             ]);
@@ -60,13 +60,14 @@ class FilepondController extends BaseController
      * Takes the given encrypted filepath and deletes
      * it if it hasn't been tampered with
      *
-     * @param Request $request
+     * @param  Request $request
+     *
      * @return mixed
      */
     public function delete(Request $request)
     {
         $filePath = $this->filepond->getPathFromServerId($request->getContent());
-        if(unlink($filePath)) {
+        if (unlink($filePath)) {
             return Response::make('', 200, [
                 'Content-Type' => 'text/plain',
             ]);

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -38,20 +38,13 @@ class FilepondController extends BaseController
             ]);
         }
 
-        $tempPath = config('filepond.temporary_files_path');
-
-        $filePath = @tempnam($tempPath, 'laravel-filepond');
-        $filePath .= '.' . $file->extension();
-
-        $filePathParts = pathinfo($filePath);
-
-        if (! $file->move($filePathParts['dirname'], $filePathParts['basename'])) {
+        if (! ($newFile = $file->storeAs(config('filepond.temporary_files_path'), $file->getClientOriginalName()))) {
             return Response::make('Could not save file', 500, [
                 'Content-Type' => 'text/plain',
             ]);
         }
 
-        return Response::make($this->filepond->getServerIdFromPath($filePath), 200, [
+        return Response::make($this->filepond->getServerIdFromPath(storage_path('app/' . $newFile)), 200, [
             'Content-Type' => 'text/plain',
         ]);
     }

--- a/src/LaravelFilepondServiceProvider.php
+++ b/src/LaravelFilepondServiceProvider.php
@@ -2,12 +2,13 @@
 
 namespace Sopamo\LaravelFilepond;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\ServiceProvider;
 
 class LaravelFilepondServiceProvider extends ServiceProvider
 {
-    public function boot() {
+    public function boot()
+    {
         $this->registerRoutes();
         $this->publishes([
             $this->getConfigFile() => config_path('filepond.php'),
@@ -37,7 +38,7 @@ class LaravelFilepondServiceProvider extends ServiceProvider
             'namespace' => 'Sopamo\LaravelFilepond\Http\Controllers',
             'middleware' => config('filepond.middleware', null),
         ], function () {
-            $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+            $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
         });
     }
 


### PR DESCRIPTION
There were a couple of Laravel components that weren't in `composer.json` but were being used, so I added those. I also cleaned up the code style a little bit to better match PSR/Laravel.

You could set up PHP-CS-Fixer to automatically fix code style. I think there is a bot for GitHub to do this on/after code is pushed.