### PR TITLE
Improve support for deleting files

### DIFF
--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -64,15 +64,20 @@ class FilepondController extends BaseController
      */
     public function delete(Request $request)
     {
-        $filePath = $this->filepond->getPathFromServerId($request->getContent());
-        if (Storage::disk(config('filepond.temporary_files_disk', 'local'))->delete($filePath)) {
+        try {
+            $filePath = $this->filepond->getPathFromServerId($request->getContent());
+            $path = pathinfo($filePath, PATHINFO_DIRNAME);
+            File::delete($filePath);
+            if (count(glob($path . '*')) === 0) {
+                rmdir($path);
+            }
             return Response::make('', 200, [
                 'Content-Type' => 'text/plain',
             ]);
+        } catch (Throwable $e) {
+            return Response::make($e->getMessage(), 500, [
+                'Content-Type' => 'text/plain',
+            ]);
         }
-
-        return Response::make('', 500, [
-            'Content-Type' => 'text/plain',
-        ]);
     }
 }

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -68,7 +68,7 @@ class FilepondController extends BaseController
             $filePath = $this->filepond->getPathFromServerId($request->getContent());
             $path = pathinfo($filePath, PATHINFO_DIRNAME);
             File::delete($filePath);
-            if (count(glob($path . '*')) === 0) {
+            if (count(glob($path . '/*')) === 0) {
                 rmdir($path);
             }
             return Response::make('', 200, [


### PR DESCRIPTION
Change the delete method to correctly remove the uploaded file, eventually remove the empty folder and retrieve a comprehensive error code in case of server error.
```php
public function delete(Request $request)
{
    try {
        $filePath = $this->filepond->getPathFromServerId($request->getContent());
        $path = pathinfo($filePath, PATHINFO_DIRNAME);
        File::delete($filePath);
        if (count(glob($path . '/*')) === 0) {
            rmdir($path);
        }
        return Response::make('', 200, [
            'Content-Type' => 'text/plain',
        ]);
    } catch (Throwable $e) {
        return Response::make($e->getMessage(), 500, [
            'Content-Type' => 'text/plain',
        ]);
    }
}
```