### PR TITLE
Fix error on delete method

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Included in this repo is a Filepond upload controller which is where you should 
 
 ```php
 // Get the temporary path using the serverId returned by the upload function in `FilepondController.php`
-$filepond = app(Sopamo\LaravelFilepond\Filepond::class);
+$filepond = app(\Sopamo\LaravelFilepond\Filepond::class);
 $path = $filepond->getPathFromServerId($serverId);
 
 // Move the file from the temporary path to the final location

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -64,8 +64,10 @@ class FilepondController extends BaseController
      */
     public function delete(Request $request)
     {
-        $filePath = $this->filepond->getPathFromServerId($request->getContent());
-        if (Storage::disk(config('filepond.temporary_files_disk', 'local'))->delete($filePath)) {
+        $absolutePathToFile = $this->filepond->getPathFromServerId($request->getContent());
+        $storagePathToFile = strstr($absolutePathToFile, config('filepond.temporary_files_path', 'storage/app'));
+        $storagePathToFolder = dirname($storagePathToFile);
+        if (Storage::disk(config('filepond.temporary_files_disk', 'local'))->deleteDirectory($storagePathToFolder)) {
             return Response::make('', 200, [
                 'Content-Type' => 'text/plain',
             ]);

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -64,10 +64,9 @@ class FilepondController extends BaseController
      */
     public function delete(Request $request)
     {
-        $absolutePathToFile = $this->filepond->getPathFromServerId($request->getContent());
-        $storagePathToFile = strstr($absolutePathToFile, config('filepond.temporary_files_path', 'storage/app'));
-        $storagePathToFolder = dirname($storagePathToFile);
-        if (Storage::disk(config('filepond.temporary_files_disk', 'local'))->deleteDirectory($storagePathToFolder)) {
+        $filePath = $this->filepond->getPathFromServerId($request->getContent());
+        $folderPath = dirname($filePath);
+        if (Storage::disk(config('filepond.temporary_files_disk', 'local'))->deleteDirectory($folderPath)) {
             return Response::make('', 200, [
                 'Content-Type' => 'text/plain',
             ]);


### PR DESCRIPTION
This PR fixes the delete method of the controller to correctly delete the folder for the uploaded file (closes #41). As mentioned in #42 it uses Laravel's `Storage` feature instead of local disk.

```php
public function delete(Request $request)
    {
        $absolutePathToFile = $this->filepond->getPathFromServerId($request->getContent());
        $storagePathToFile = strstr($absolutePathToFile, config('filepond.temporary_files_path', 'storage/app'));
        $storagePathToFolder = dirname($storagePathToFile);
        if (Storage::disk(config('filepond.temporary_files_disk', 'local'))->deleteDirectory($storagePathToFolder)) {
            return Response::make('', 200, [
                'Content-Type' => 'text/plain',
            ]);
        }

        return Response::make('', 500, [
            'Content-Type' => 'text/plain',
        ]);
    }```

