### PR TITLE
Fix large saved files not being preview-able (only downloaded)

### DIFF
--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -70,7 +70,8 @@ class FilepondController extends BaseController
 
         $baseName = $randomId;
         if ($request->header('Upload-Name')) {
-            $baseName = pathinfo($request->header('Upload-Name'), PATHINFO_BASENAME).'-'.$randomId;
+            $fileName = pathinfo($request->header('Upload-Name'), PATHINFO_FILENAME);
+            $baseName = $fileName.'-'.$randomId;
         }
         $fileLocation = $path . DIRECTORY_SEPARATOR . $baseName;
 

--- a/src/Http/Controllers/FilepondController.php
+++ b/src/Http/Controllers/FilepondController.php
@@ -175,7 +175,7 @@ class FilepondController extends BaseController
         // Append each chunk to the final file
         foreach ($chunks as $chunk) {
             // Get chunk contents
-            $chunkContents = $storage->readStream($chunk['path']);
+            $chunkContents = $storage->readStream($chunk);
 
             // Stream data from chunk to tmp file
             stream_copy_to_stream($chunkContents, $tmpFile);


### PR DESCRIPTION
Issue: When we upload large files using chunks, we weren't able to preview the file content like (pdf files) in browser, and it will be downloaded automatically.

Solution: Filepond js always send file name under header `Upload-Name` in chunks api, you can check here (https://pqina.nl/filepond/docs/api/server/#process-chunks), so what i did is:
- Add the file name to `process` config in you filepond component configuration to have the same name in chunks.
```
 process: {
    url: "/process",
    headers: (file: File) => {
      return { ...defaultHeaders, "Upload-Name": file.name }
    },
    withCredentials: true,
  },
```
- Now `$filepondId` in `FilepondController@handleChunkInitialization:81` will have the file name as index instead of random id.
- Saving file chunks using append method in `Storage` facade instead of saving the whole file content with specific mimetype.